### PR TITLE
Fix README.md. Replace "extends" with "implements"

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ If you are using Flutter consider the [dependencies_flutter](https://pub.dartlan
 Optionally create a module.
 
 ```dart
-class PlayerModule extends Module {
+class PlayerModule implements Module {
   @override
   void configure(Binder binder) {
     binder


### PR DESCRIPTION
Wrong way to inherit own module from base.